### PR TITLE
Fixing the issue of not being able to submit work request with more than 1 workers

### DIFF
--- a/web/src/components/PlanWorkComponent/PlanWorkComponent.tsx
+++ b/web/src/components/PlanWorkComponent/PlanWorkComponent.tsx
@@ -99,7 +99,7 @@ const PlanWorkComponent = ({
     endDate: z.string().min(1),
     jobProfileId: z.string().min(1),
     addressId: z.string().min(1),
-    numWorkers: z.number().min(1),
+    numWorkers: z.coerce.number().min(1),
   })
 
   const currentDefaultValues = useMemo<z.infer<typeof formSchema>>(


### PR DESCRIPTION
This PR fixes the issue of inability to submit a work request with more than 1 worker. 

The PR coerces the number of worker field to be a value from a string.

Fixes #60 