### PR TITLE
Making the menu item buttons full width

### DIFF
--- a/web/src/layouts/AppLayout/AppLayout.tsx
+++ b/web/src/layouts/AppLayout/AppLayout.tsx
@@ -109,19 +109,19 @@ const AppLayout = ({ children }: AppLayoutProps) => {
                 </DropdownMenuLabel>
                 <DropdownMenuSeparator className=" bg-accent/30" />
                 <DropdownMenuItem>
-                  <button className="flex">
+                  <button className="flex w-full">
                     <User2Icon size={16} className="mr-1" />
                     Profiel
                   </button>
                 </DropdownMenuItem>
                 <DropdownMenuItem>
-                  <button className="flex">
+                  <button className="flex w-full">
                     <LucideSettings size={16} className="mr-1" />
                     Settings
                   </button>
                 </DropdownMenuItem>
                 <DropdownMenuItem>
-                  <button className="flex" onClick={logOut}>
+                  <button className="flex w-full" onClick={logOut}>
                     <LogOutIcon size={16} className="mr-1" />
                     Logout
                   </button>


### PR DESCRIPTION
This PR makes the menu item buttons full-width:

Before:
<img width="320" alt="image" src="https://github.com/user-attachments/assets/e5f8e15c-4093-421e-9a66-98ad82bf194e">

After:
<img width="317" alt="image" src="https://github.com/user-attachments/assets/8e2de731-1e34-4a61-b1d5-a62d3d1336c8">

Fixes #72 